### PR TITLE
bump gulp-sass (for developers running a bleeding edge version of node)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
   "name": "simplicity",
+  "description": "UI to simplify city data",
   "version": "0.0.1",
-  "description": "UI to simlify city data",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "author": "Cameron Carlyle ccarlyle@ashevillenc.gov",
-  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/CodeForAsheville/simplicity-esri/issues"
+  },
   "devDependencies": {
     "angular-mocks": "^1.3.0",
     "browser-sync": "^1.5.7",
@@ -26,7 +24,7 @@
     "gulp-ng-html2js": "^0.1.8",
     "gulp-rename": "^1.2.0",
     "gulp-rev": "^1.1.0",
-    "gulp-sass": "^1.0.0",
+    "gulp-sass": "^2.0.4",
     "gulp-size": "^1.1.0",
     "gulp-uglify": "^1.0.1",
     "jshint-stylish": "^1.0.0",
@@ -42,5 +40,14 @@
     "require-dir": "^0.1.0",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.6.0"
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/CodeForAsheville/simplicity-esri.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }


### PR DESCRIPTION
just took my first :fork_and_knife: at setting the site up locally and ran into errors installing `node-sass` because i'm running [version 4.1.1](http://stackoverflow.com/questions/32594885/error-running-gulp-sass-after-update-to-node-v4-0-0) of node.

everything looked good after bumping `gulp-sass` (and leaving the rest of the dependencies alone), but i can't say i'm an authority on the subject.
